### PR TITLE
Rocket league spotify dpad controller integration

### DIFF
--- a/rl-spotify-dpad-plugin/README.md
+++ b/rl-spotify-dpad-plugin/README.md
@@ -1,0 +1,65 @@
+# RL Spotify D-pad Plugin (BakkesMod)
+
+Control Spotify (or any media player that honors system media keys) using your controller D-pad while playing Rocket League.
+
+- Play/Pause
+- Next track
+- Previous track
+
+Note: This plugin uses Windows media key events. It requires running Rocket League + BakkesMod on Windows.
+
+## Build
+
+1. Install Visual Studio 2019/2022 (MSVC, Desktop development with C++).
+2. Install the BakkesMod Plugin SDK template:
+   - Recommended: Use the official template (`bakkesmod/bakkesmod-plugin-template`).
+3. Add these two files to your plugin's source folder:
+   - `SpotifyControllerPlugin.h`
+   - `SpotifyControllerPlugin.cpp`
+4. Ensure the include path contains the BakkesMod SDK headers and you link against the BakkesMod libraries as per the template.
+5. Build the project to produce a DLL.
+
+## Install
+
+1. Copy the built DLL into your BakkesMod `plugins` folder, e.g.:
+   - `%appdata%/bakkesmod/bakkesmod/plugins/SpotifyController.dll`
+2. Add the plugin to your BakkesMod config or load it manually in the BakkesMod console:
+   - `plugin load SpotifyController` (replace with your actual DLL name if different)
+
+## Bind your D-pad
+
+Use the one-shot helper, or bind manually.
+
+- Helper:
+  - `spotify_setup_binds`
+- Manual:
+```
+bind XboxTypeS_DPad_Up spotify_play_pause
+bind XboxTypeS_DPad_Right spotify_next
+bind XboxTypeS_DPad_Left spotify_prev
+```
+
+You can bind to any key or button; the above are just examples for Xbox-style controllers.
+
+## Provided commands
+
+- `spotify_play_pause`: Toggle play/pause
+- `spotify_next`: Next track
+- `spotify_prev`: Previous track
+- `spotify_setup_binds`: Apply default Xbox D-pad binds (Up/Right/Left)
+
+## How it works
+
+- The plugin registers the commands above as notifiers.
+- Triggering a notifier sends the corresponding Windows media key event (`VK_MEDIA_PLAY_PAUSE`, `VK_MEDIA_NEXT_TRACK`, `VK_MEDIA_PREV_TRACK`).
+- Spotify (and most media players) respond to these events even when Rocket League is focused.
+
+## Troubleshooting
+
+- If binds do not trigger, verify your key name. Use BakkesMod's keybind helper or try binding to a keyboard key first to validate.
+- If media keys do nothing, ensure Spotify is running and that system media keys work outside the game (e.g., from your keyboard).
+- Steam Input remaps can override D-pad behavior. If needed, disable Steam Input for Rocket League or adjust your Steam controller layout.
+
+## Platform note
+
+- Windows only. If you need Linux support, you would need to adapt the code to call an external controller (e.g., `playerctl` via DBus/MPRIS) or run a small companion process. If you want that, let me know.

--- a/rl-spotify-dpad-plugin/README.md
+++ b/rl-spotify-dpad-plugin/README.md
@@ -6,7 +6,7 @@ Control Spotify (or any media player that honors system media keys) using your c
 - Next track
 - Previous track
 
-Note: This plugin uses Windows media key events. It requires running Rocket League + BakkesMod on Windows.
+Note: This plugin uses Windows media key events. It is intended primarily for Windows (Rocket League + BakkesMod on Windows).
 
 ## Build
 
@@ -28,18 +28,51 @@ Note: This plugin uses Windows media key events. It requires running Rocket Leag
 
 ## Bind your D-pad
 
-Use the one-shot helper, or bind manually.
+Use a helper or bind manually.
 
-- Helper:
-  - `spotify_setup_binds`
-- Manual:
+- All controllers (apply all three presets):
+  - `spotify_setup_binds_all`
+- Xbox only:
+  - `spotify_setup_binds_xbox` or `spotify_setup_binds` (alias)
+- PlayStation only:
+  - `spotify_setup_binds_ps`
+- Nintendo/Switch only:
+  - `spotify_setup_binds_nintendo`
+
+Manual examples:
 ```
+# Xbox
 bind XboxTypeS_DPad_Up spotify_play_pause
 bind XboxTypeS_DPad_Right spotify_next
 bind XboxTypeS_DPad_Left spotify_prev
+
+# PlayStation (variants; depends on drivers/Steam Input)
+bind PS4_DPad_Up spotify_play_pause
+bind PS4_DPad_Right spotify_next
+bind PS4_DPad_Left spotify_prev
+bind PS5_DPad_Up spotify_play_pause
+bind PS5_DPad_Right spotify_next
+bind PS5_DPad_Left spotify_prev
+bind DualShock4_DPad_Up spotify_play_pause
+bind DualShock4_DPad_Right spotify_next
+bind DualShock4_DPad_Left spotify_prev
+bind DualSense_DPad_Up spotify_play_pause
+bind DualSense_DPad_Right spotify_next
+bind DualSense_DPad_Left spotify_prev
+
+# Nintendo/Switch (variants; depends on drivers/Steam Input)
+bind SwitchPro_DPad_Up spotify_play_pause
+bind SwitchPro_DPad_Right spotify_next
+bind SwitchPro_DPad_Left spotify_prev
+bind NintendoSwitchPro_DPad_Up spotify_play_pause
+bind NintendoSwitchPro_DPad_Right spotify_next
+bind NintendoSwitchPro_DPad_Left spotify_prev
+bind NintendoSwitch_DPad_Up spotify_play_pause
+bind NintendoSwitch_DPad_Right spotify_next
+bind NintendoSwitch_DPad_Left spotify_prev
 ```
 
-You can bind to any key or button; the above are just examples for Xbox-style controllers.
+You can bind to any key or button; the above are examples for common controller layouts and name variants.
 
 ## Provided commands
 
@@ -47,6 +80,10 @@ You can bind to any key or button; the above are just examples for Xbox-style co
 - `spotify_next`: Next track
 - `spotify_prev`: Previous track
 - `spotify_setup_binds`: Apply default Xbox D-pad binds (Up/Right/Left)
+- `spotify_setup_binds_xbox`: Apply Xbox binds
+- `spotify_setup_binds_ps`: Apply PlayStation binds (multiple variants)
+- `spotify_setup_binds_nintendo`: Apply Nintendo/Switch binds (multiple variants)
+- `spotify_setup_binds_all`: Apply all of the above
 
 ## How it works
 
@@ -59,7 +96,8 @@ You can bind to any key or button; the above are just examples for Xbox-style co
 - If binds do not trigger, verify your key name. Use BakkesMod's keybind helper or try binding to a keyboard key first to validate.
 - If media keys do nothing, ensure Spotify is running and that system media keys work outside the game (e.g., from your keyboard).
 - Steam Input remaps can override D-pad behavior. If needed, disable Steam Input for Rocket League or adjust your Steam controller layout.
+- Some controller names depend on your drivers and whether Steam Input is translating to XInput. If the helper presets do not work, press buttons while viewing BakkesMod's keybind UI to see the exact names and bind those manually.
 
 ## Platform note
 
-- Windows only. If you need Linux support, you would need to adapt the code to call an external controller (e.g., `playerctl` via DBus/MPRIS) or run a small companion process. If you want that, let me know.
+- Windows only (for now). If you want Linux support, we can add an MPRIS/`playerctl` backend or a small companion process.

--- a/rl-spotify-dpad-plugin/SpotifyControllerPlugin.cpp
+++ b/rl-spotify-dpad-plugin/SpotifyControllerPlugin.cpp
@@ -1,0 +1,95 @@
+#include "SpotifyControllerPlugin.h"
+#include <vector>
+#include <string>
+
+BAKKESMOD_PLUGIN(SpotifyControllerPlugin, "Control Spotify with controller D-pad via media keys", "1.0.0", 0)
+
+void SpotifyControllerPlugin::onLoad()
+{
+	cvarManager->registerNotifier(
+		"spotify_play_pause",
+		[this](std::vector<std::string> /*args*/) { PlayPause(); },
+		"Toggle play/pause via media key",
+		PERMISSION_ALL);
+
+	cvarManager->registerNotifier(
+		"spotify_next",
+		[this](std::vector<std::string> /*args*/) { NextTrack(); },
+		"Next track via media key",
+		PERMISSION_ALL);
+
+	cvarManager->registerNotifier(
+		"spotify_prev",
+		[this](std::vector<std::string> /*args*/) { PreviousTrack(); },
+		"Previous track via media key",
+		PERMISSION_ALL);
+
+	cvarManager->registerNotifier(
+		"spotify_setup_binds",
+		[this](std::vector<std::string> /*args*/) { SetupDefaultBinds(); },
+		"Bind Xbox D-pad Up/Right/Left to play/pause, next, previous",
+		PERMISSION_ALL);
+
+	cvarManager->log("SpotifyController loaded. Example binds: bind XboxTypeS_DPad_Up spotify_play_pause");
+}
+
+void SpotifyControllerPlugin::onUnload()
+{
+	// Nothing to clean up
+}
+
+void SpotifyControllerPlugin::PlayPause()
+{
+#ifdef _WIN32
+	SendMediaKey(VK_MEDIA_PLAY_PAUSE);
+#else
+	cvarManager->log("spotify_play_pause: Unsupported platform. This plugin requires Windows.");
+#endif
+}
+
+void SpotifyControllerPlugin::NextTrack()
+{
+#ifdef _WIN32
+	SendMediaKey(VK_MEDIA_NEXT_TRACK);
+#else
+	cvarManager->log("spotify_next: Unsupported platform. This plugin requires Windows.");
+#endif
+}
+
+void SpotifyControllerPlugin::PreviousTrack()
+{
+#ifdef _WIN32
+	SendMediaKey(VK_MEDIA_PREV_TRACK);
+#else
+	cvarManager->log("spotify_prev: Unsupported platform. This plugin requires Windows.");
+#endif
+}
+
+void SpotifyControllerPlugin::SetupDefaultBinds()
+{
+	if (!gameWrapper) return;
+	// Issue bind commands through the console
+	cvarManager->executeCommand("bind XboxTypeS_DPad_Up spotify_play_pause");
+	cvarManager->executeCommand("bind XboxTypeS_DPad_Right spotify_next");
+	cvarManager->executeCommand("bind XboxTypeS_DPad_Left spotify_prev");
+	cvarManager->log("SpotifyController: Default binds applied for Xbox D-pad (Up/Right/Left).");
+}
+
+#ifdef _WIN32
+void SpotifyControllerPlugin::SendMediaKey(WORD vk)
+{
+	INPUT inputs[2] = {};
+	inputs[0].type = INPUT_KEYBOARD;
+	inputs[0].ki.wVk = vk;
+
+	inputs[1].type = INPUT_KEYBOARD;
+	inputs[1].ki.wVk = vk;
+	inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+
+	UINT sent = SendInput(2, inputs, sizeof(INPUT));
+	if (sent != 2)
+	{
+		cvarManager->log("SpotifyController: SendInput failed.");
+	}
+}
+#endif

--- a/rl-spotify-dpad-plugin/SpotifyControllerPlugin.cpp
+++ b/rl-spotify-dpad-plugin/SpotifyControllerPlugin.cpp
@@ -30,6 +30,30 @@ void SpotifyControllerPlugin::onLoad()
 		"Bind Xbox D-pad Up/Right/Left to play/pause, next, previous",
 		PERMISSION_ALL);
 
+	cvarManager->registerNotifier(
+		"spotify_setup_binds_xbox",
+		[this](std::vector<std::string> /*args*/) { SetupBindsXbox(); },
+		"Bind Xbox D-pad Up/Right/Left to play/pause, next, previous",
+		PERMISSION_ALL);
+
+	cvarManager->registerNotifier(
+		"spotify_setup_binds_ps",
+		[this](std::vector<std::string> /*args*/) { SetupBindsPlayStation(); },
+		"Bind PlayStation D-pad Up/Right/Left to play/pause, next, previous",
+		PERMISSION_ALL);
+
+	cvarManager->registerNotifier(
+		"spotify_setup_binds_nintendo",
+		[this](std::vector<std::string> /*args*/) { SetupBindsNintendo(); },
+		"Bind Nintendo/Switch D-pad Up/Right/Left to play/pause, next, previous",
+		PERMISSION_ALL);
+
+	cvarManager->registerNotifier(
+		"spotify_setup_binds_all",
+		[this](std::vector<std::string> /*args*/) { SetupBindsAll(); },
+		"Apply binds for Xbox, PlayStation, and Nintendo/Switch D-pads",
+		PERMISSION_ALL);
+
 	cvarManager->log("SpotifyController loaded. Example binds: bind XboxTypeS_DPad_Up spotify_play_pause");
 }
 
@@ -68,11 +92,65 @@ void SpotifyControllerPlugin::PreviousTrack()
 void SpotifyControllerPlugin::SetupDefaultBinds()
 {
 	if (!gameWrapper) return;
-	// Issue bind commands through the console
+	// Issue bind commands through the console (Xbox defaults)
 	cvarManager->executeCommand("bind XboxTypeS_DPad_Up spotify_play_pause");
 	cvarManager->executeCommand("bind XboxTypeS_DPad_Right spotify_next");
 	cvarManager->executeCommand("bind XboxTypeS_DPad_Left spotify_prev");
 	cvarManager->log("SpotifyController: Default binds applied for Xbox D-pad (Up/Right/Left).");
+}
+
+void SpotifyControllerPlugin::SetupBindsXbox()
+{
+	if (!gameWrapper) return;
+	cvarManager->executeCommand("bind XboxTypeS_DPad_Up spotify_play_pause");
+	cvarManager->executeCommand("bind XboxTypeS_DPad_Right spotify_next");
+	cvarManager->executeCommand("bind XboxTypeS_DPad_Left spotify_prev");
+	cvarManager->log("SpotifyController: Xbox binds applied.");
+}
+
+void SpotifyControllerPlugin::SetupBindsPlayStation()
+{
+	if (!gameWrapper) return;
+	// Common PlayStation mappings (PS4/PS5/DualShock4/DualSense). These may vary based on drivers/Steam Input.
+	const std::vector<std::string> psPrefixes = {
+		"PS4",
+		"PS5",
+		"DualShock4",
+		"DualSense"
+	};
+	for (const auto& prefix : psPrefixes)
+	{
+		cvarManager->executeCommand("bind " + prefix + "_DPad_Up spotify_play_pause");
+		cvarManager->executeCommand("bind " + prefix + "_DPad_Right spotify_next");
+		cvarManager->executeCommand("bind " + prefix + "_DPad_Left spotify_prev");
+	}
+	cvarManager->log("SpotifyController: PlayStation binds applied (PS4/PS5/DualShock4/DualSense).");
+}
+
+void SpotifyControllerPlugin::SetupBindsNintendo()
+{
+	if (!gameWrapper) return;
+	// Common Nintendo/Switch mappings. Names depend on drivers/Steam Input; we bind several likely variants.
+	const std::vector<std::string> nsPrefixes = {
+		"SwitchPro",
+		"NintendoSwitchPro",
+		"NintendoSwitch"
+	};
+	for (const auto& prefix : nsPrefixes)
+	{
+		cvarManager->executeCommand("bind " + prefix + "_DPad_Up spotify_play_pause");
+		cvarManager->executeCommand("bind " + prefix + "_DPad_Right spotify_next");
+		cvarManager->executeCommand("bind " + prefix + "_DPad_Left spotify_prev");
+	}
+	cvarManager->log("SpotifyController: Nintendo/Switch binds applied (multiple variants).");
+}
+
+void SpotifyControllerPlugin::SetupBindsAll()
+{
+	SetupBindsXbox();
+	SetupBindsPlayStation();
+	SetupBindsNintendo();
+	cvarManager->log("SpotifyController: All controller binds applied (Xbox + PlayStation + Nintendo/Switch).");
 }
 
 #ifdef _WIN32

--- a/rl-spotify-dpad-plugin/SpotifyControllerPlugin.h
+++ b/rl-spotify-dpad-plugin/SpotifyControllerPlugin.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
+#include "bakkesmod/plugin/bakkesmodplugin.h"
+
+class SpotifyControllerPlugin final : public BakkesMod::Plugin::BakkesModPlugin
+{
+public:
+	void onLoad() override;
+	void onUnload() override;
+
+private:
+	void PlayPause();
+	void NextTrack();
+	void PreviousTrack();
+	void SetupDefaultBinds();
+
+#ifdef _WIN32
+	void SendMediaKey(WORD virtualKeyCode);
+#endif
+};

--- a/rl-spotify-dpad-plugin/SpotifyControllerPlugin.h
+++ b/rl-spotify-dpad-plugin/SpotifyControllerPlugin.h
@@ -18,6 +18,10 @@ private:
 	void NextTrack();
 	void PreviousTrack();
 	void SetupDefaultBinds();
+	void SetupBindsXbox();
+	void SetupBindsPlayStation();
+	void SetupBindsNintendo();
+	void SetupBindsAll();
 
 #ifdef _WIN32
 	void SendMediaKey(WORD virtualKeyCode);


### PR DESCRIPTION
Adds a BakkesMod plugin to control Spotify (or other media players) using controller D-pad via Windows media keys.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fbb3b18-5b39-4b8b-9a97-4b0660456b24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3fbb3b18-5b39-4b8b-9a97-4b0660456b24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

